### PR TITLE
Add Agents tab with deployment button

### DIFF
--- a/solomon-reasoning-engine/src/hooks/useCodexAI.ts
+++ b/solomon-reasoning-engine/src/hooks/useCodexAI.ts
@@ -1,0 +1,12 @@
+import { useCallback } from "react";
+
+export function useCodexAI() {
+  const deployCodexAgent = useCallback(() => {
+    console.log("deployCodexAgent called");
+  }, []);
+
+  return {
+    deployCodexAgent,
+  };
+}
+

--- a/solomon-reasoning-engine/src/pages/Dashboard.tsx
+++ b/solomon-reasoning-engine/src/pages/Dashboard.tsx
@@ -2,18 +2,32 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BarChart3, BookOpenCheck, Brain, DatabaseZap, Landmark } from "lucide-react";
+import { useState } from "react";
+import { useCodexAI } from "../hooks/useCodexAI";
 
 export default function Dashboard() {
+  const { deployCodexAgent } = useCodexAI();
+  const [activityLog, setActivityLog] = useState<string[]>([]);
+
+  const handleDeploy = () => {
+    deployCodexAgent();
+    setActivityLog((prev) => [
+      ...prev,
+      `Deployed agent at ${new Date().toLocaleTimeString()}`,
+    ]);
+  };
+
   return (
     <div className="p-6 space-y-4">
       <h1 className="text-3xl font-bold">🧠 Solomon Reasoning Engine Dashboard</h1>
       <Tabs defaultValue="law" className="w-full">
-        <TabsList className="grid grid-cols-5 w-full">
+        <TabsList className="grid grid-cols-6 w-full">
           <TabsTrigger value="law">Law Core</TabsTrigger>
           <TabsTrigger value="wisdom">Wisdom Modules</TabsTrigger>
           <TabsTrigger value="memory">Memory Cache</TabsTrigger>
           <TabsTrigger value="visual">Visual Logic</TabsTrigger>
           <TabsTrigger value="docs">Documentation</TabsTrigger>
+          <TabsTrigger value="agents">Agents</TabsTrigger>
         </TabsList>
 
         <TabsContent value="law">
@@ -72,6 +86,30 @@ export default function Dashboard() {
               <Button variant="secondary" className="mt-2">Read Full Codex</Button>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="agents">
+          <Card>
+            <CardContent className="p-4 space-y-2">
+              <h2 className="text-xl font-semibold">Self-PlayGPT</h2>
+              <p>Autonomously iterates on tasks through self-play.</p>
+            </CardContent>
+          </Card>
+          <Card className="mt-4">
+            <CardContent className="p-4 space-y-2">
+              <h2 className="text-xl font-semibold">MemoryGPT</h2>
+              <p>Stores and recalls context across sessions.</p>
+            </CardContent>
+          </Card>
+          <Button className="mt-4" onClick={handleDeploy}>Deploy Agent</Button>
+          <div className="mt-4">
+            <h3 className="font-semibold">Activity Log</h3>
+            <ul className="list-disc ml-6">
+              {activityLog.map((entry, idx) => (
+                <li key={idx}>{entry}</li>
+              ))}
+            </ul>
+          </div>
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
## Summary
- add a simple `useCodexAI` hook with `deployCodexAgent`
- extend Dashboard with an **Agents** tab
- show Self-PlayGPT and MemoryGPT summary cards
- add Deploy Agent button and activity log

## Testing
- `python -m pip install --upgrade pip`
- `pip install pylint`
- `pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867183b019c832abe36f433154a2340