### PR TITLE
Add DeepSeek engine implementation

### DIFF
--- a/engines/deepseek/agents/selfReflector.ts
+++ b/engines/deepseek/agents/selfReflector.ts
@@ -1,0 +1,3 @@
+export const selfReflector = (steps: any[]): string => {
+  return `Reflection: ${steps.map(s => s.thought).join(' -> ')}`;
+};

--- a/engines/deepseek/components/AgentSelector.tsx
+++ b/engines/deepseek/components/AgentSelector.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const agents = ['default', 'selfReflector', 'explainer', 'analyzer'];
+
+export const AgentSelector = ({ selected, onChange }: { selected: string, onChange: (agent: string) => void }) => (
+  <div className="p-4">
+    <label className="block mb-2 font-medium">Select Agent:</label>
+    <select
+      value={selected}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full p-2 border border-gray-300 rounded"
+    >
+      {agents.map(agent => (
+        <option key={agent} value={agent}>{agent}</option>
+      ))}
+    </select>
+  </div>
+);

--- a/engines/deepseek/components/DeepSeekPage.tsx
+++ b/engines/deepseek/components/DeepSeekPage.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { useDeepSeek } from '../hooks/useDeepSeek';
+import { StepVisualizer } from './StepVisualizer';
+import { PromptDisplay } from './PromptDisplay';
+import { AgentSelector } from './AgentSelector';
+import { buildPrompt } from '../core/promptBuilder';
+
+export const DeepSeekPage = () => {
+  const [input, setInput] = useState('');
+  const [agent, setAgent] = useState('default');
+  const { result, steps, execute } = useDeepSeek();
+
+  const handleRun = () => {
+    execute(input, agent);
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">DeepSeek Reasoning Engine</h1>
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        className="w-full p-2 border rounded mb-4"
+        rows={4}
+        placeholder="Enter your query here..."
+      />
+      <AgentSelector selected={agent} onChange={setAgent} />
+      <button
+        onClick={handleRun}
+        className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        Run DeepSeek
+      </button>
+      {result && (
+        <div className="mt-6">
+          <h2 className="text-xl font-semibold mb-2">Result</h2>
+          <div className="p-2 bg-green-100 rounded mb-4">{result}</div>
+          <StepVisualizer steps={steps} />
+          <PromptDisplay prompt={buildPrompt(input)} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/engines/deepseek/components/PromptDisplay.tsx
+++ b/engines/deepseek/components/PromptDisplay.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const PromptDisplay = ({ prompt }: { prompt: string }) => (
+  <pre className="bg-black text-green-400 p-4 rounded text-sm overflow-auto">
+    {prompt}
+  </pre>
+);

--- a/engines/deepseek/components/StepVisualizer.tsx
+++ b/engines/deepseek/components/StepVisualizer.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const StepVisualizer = ({ steps }: { steps: any[] }) => (
+  <div className="p-4">
+    {steps.map((step, idx) => (
+      <div key={step.id} className="mb-2 p-2 rounded bg-gray-100">
+        <div className="font-semibold">Step {idx + 1}</div>
+        <div>{step.thought}</div>
+      </div>
+    ))}
+  </div>
+);

--- a/engines/deepseek/core/context.ts
+++ b/engines/deepseek/core/context.ts
@@ -1,0 +1,4 @@
+export interface DeepSeekContext {
+  history: string[];
+  currentStep: number;
+}

--- a/engines/deepseek/core/deepseek.ts
+++ b/engines/deepseek/core/deepseek.ts
@@ -1,0 +1,16 @@
+import { buildPrompt } from './promptBuilder';
+import { parseSteps } from '../lib/parser';
+import { selfReflector } from '../agents/selfReflector';
+
+export const runDeepSeek = async (input: string, agent: string = 'default') => {
+  const prompt = buildPrompt(input);
+  const rawOutput = input; // placeholder for real engine output
+  const steps = parseSteps(rawOutput);
+  let result = `Processed by ${agent}: ${input}`;
+
+  if (agent === 'selfReflector') {
+    result = selfReflector(steps);
+  }
+
+  return { result, steps, prompt };
+};

--- a/engines/deepseek/core/promptBuilder.ts
+++ b/engines/deepseek/core/promptBuilder.ts
@@ -1,0 +1,3 @@
+export const buildPrompt = (input: string): string => {
+  return `DeepSeek Reasoning:\nInput: ${input}\nSteps:`;
+};

--- a/engines/deepseek/core/stepTypes.ts
+++ b/engines/deepseek/core/stepTypes.ts
@@ -1,0 +1,5 @@
+export interface DeepSeekStep {
+  id: string;
+  thought: string;
+  rationale?: string;
+}

--- a/engines/deepseek/hooks/useDeepSeek.ts
+++ b/engines/deepseek/hooks/useDeepSeek.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import { runDeepSeek } from '../core/deepseek';
+
+export const useDeepSeek = () => {
+  const [result, setResult] = useState<string | null>(null);
+  const [steps, setSteps] = useState<any[]>([]);
+
+  const execute = async (input: string, agent: string = 'default') => {
+    const output = await runDeepSeek(input, agent);
+    setResult(output.result);
+    setSteps(output.steps);
+  };
+
+  return { result, steps, execute };
+};

--- a/engines/deepseek/hooks/useStepTrace.ts
+++ b/engines/deepseek/hooks/useStepTrace.ts
@@ -1,0 +1,5 @@
+import { useMemo } from 'react';
+
+export const useStepTrace = (steps: any[]) => {
+  return useMemo(() => steps.map((s, i) => ({ ...s, index: i + 1 })), [steps]);
+};

--- a/engines/deepseek/index.ts
+++ b/engines/deepseek/index.ts
@@ -1,0 +1,4 @@
+export * from './core/deepseek';
+export * from './hooks/useDeepSeek';
+export * from './components/AgentSelector';
+export * from './components/DeepSeekPage';

--- a/engines/deepseek/lib/parser.ts
+++ b/engines/deepseek/lib/parser.ts
@@ -1,0 +1,3 @@
+export const parseSteps = (rawOutput: string): any[] => {
+  return rawOutput.split('\n').map((line, idx) => ({ id: `${idx}`, thought: line }));
+};

--- a/engines/deepseek/lib/tokenizer.ts
+++ b/engines/deepseek/lib/tokenizer.ts
@@ -1,0 +1,3 @@
+export const countTokens = (text: string): number => {
+  return text.split(/\s+/).length;
+};

--- a/engines/deepseek/tests/deepseek.test.ts
+++ b/engines/deepseek/tests/deepseek.test.ts
@@ -1,0 +1,4 @@
+test('DeepSeek basic run', async () => {
+  const { result } = await import('../core/deepseek').then(m => m.runDeepSeek('test input'));
+  expect(result).toContain('Processed');
+});

--- a/engines/deepseek/tests/promptBuilder.test.ts
+++ b/engines/deepseek/tests/promptBuilder.test.ts
@@ -1,0 +1,4 @@
+test('Prompt Builder builds correctly', () => {
+  const { buildPrompt } = require('../core/promptBuilder');
+  expect(buildPrompt('test')).toContain('Input: test');
+});


### PR DESCRIPTION
## Summary
- implement DeepSeek reasoning engine scaffolding
- provide hooks and React components
- add simple agent and utilities
- include basic tests

## Testing
- `npx jest` *(fails: Need to install jest)*
- `npm test` in `solomon-reasoning-engine` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867d61edbcc832a894ecf190bd0a013