### PR TITLE
Add symbolic logging utility and view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# Solomon-Ai-Dashboard-
+# Solomon-Ai-Dashboard
+
+This repository contains a small prototype of the Solomon reasoning engine.
+
+## Symbolic Logging
+
+The dashboard includes a symbolic logging system with a real-time log view.
+Logs can be exported as JSON or shared via a webhook endpoint.
+See `SymbolicLogView` for the UI and `api/share-symbolic-logs.ts` for the share handler.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ This repository contains a small prototype of the Solomon reasoning engine.
 The dashboard includes a symbolic logging system with a real-time log view.
 Logs can be exported as JSON or shared via a webhook endpoint.
 See `SymbolicLogView` for the UI and `api/share-symbolic-logs.ts` for the share handler.
+
+## Wisdom Thread Preview ![Preview](https://img.shields.io/badge/preview-available-green)
+
+A multilingual wisdom visualization is available alongside the symbolic log. Use `ReasoningTabs` to toggle between the log view and the animated `WisdomThread` with language selector (English, Dutch, Papiamento).

--- a/api/share-symbolic-logs.ts
+++ b/api/share-symbolic-logs.ts
@@ -1,0 +1,14 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  // In a real app this would forward logs to a webhook or external service.
+  // This scaffold simply returns success.
+  const logs = req.body;
+  console.log('Received symbolic logs', logs);
+  res.status(200).json({ status: 'ok' });
+}

--- a/solomon-reasoning-engine/README.md
+++ b/solomon-reasoning-engine/README.md
@@ -1,3 +1,7 @@
 # Solomon Reasoning Engine
 
-A visual AI dashboard inspired by Solomon's wisdom. This project provides an interactive interface for exploring reasoning laws, wisdom modules, memory caching, visual logic, and documentation. The dashboard is designed to facilitate understanding and application of reasoning principles in a user-friendly manner.
+A visual AI dashboard inspired by Solomon's wisdom. This project provides an interactive interface for exploring reasoning laws, wisdom modules, memory caching, visual logic and documentation.
+
+## Symbolic Log Utilities
+
+The `src/lib/symbolicLogger.ts` file implements a lightweight logger used throughout the dashboard. The `SymbolicLogView` component displays these logs with filters and options to export or share them via `/api/share-symbolic-logs`.

--- a/solomon-reasoning-engine/README.md
+++ b/solomon-reasoning-engine/README.md
@@ -5,3 +5,7 @@ A visual AI dashboard inspired by Solomon's wisdom. This project provides an int
 ## Symbolic Log Utilities
 
 The `src/lib/symbolicLogger.ts` file implements a lightweight logger used throughout the dashboard. The `SymbolicLogView` component displays these logs with filters and options to export or share them via `/api/share-symbolic-logs`.
+
+## Wisdom Thread and Tabs
+
+`WisdomThread` visualizes reasoning steps with framer-motion animations and supports English, Dutch and Papiamento via `i18n.ts`. Use `ReasoningTabs` to switch between the log view and the wisdom thread.

--- a/solomon-reasoning-engine/src/components
+++ b/solomon-reasoning-engine/src/components
@@ -1,1 +1,0 @@
-# This file is intentionally left blank.

--- a/solomon-reasoning-engine/src/components/ReasoningTabs.tsx
+++ b/solomon-reasoning-engine/src/components/ReasoningTabs.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import SymbolicLogView from './SymbolicLogView';
+import WisdomThread from './WisdomThread';
+
+export default function ReasoningTabs() {
+  const [tab, setTab] = useState<'log' | 'wisdom'>('log');
+
+  return (
+    <div>
+      <div className="flex space-x-2 mb-2">
+        <button
+          className={`border px-2 ${tab === 'log' ? 'bg-gray-200' : ''}`}
+          onClick={() => setTab('log')}
+        >
+          Symbolic Log
+        </button>
+        <button
+          className={`border px-2 ${tab === 'wisdom' ? 'bg-gray-200' : ''}`}
+          onClick={() => setTab('wisdom')}
+        >
+          Wisdom Thread
+        </button>
+      </div>
+      {tab === 'log' ? <SymbolicLogView /> : <WisdomThread />}
+    </div>
+  );
+}

--- a/solomon-reasoning-engine/src/components/SymbolicLogView.tsx
+++ b/solomon-reasoning-engine/src/components/SymbolicLogView.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { symbolicLogger, SymbolicLog } from '../lib/symbolicLogger';
+import { useSymbolicLog } from '../hooks/useSymbolicLog';
+
+export default function SymbolicLogView() {
+  const [level, setLevel] = useState('');
+  const [search, setSearch] = useState('');
+  const logs = useSymbolicLog(1000, {
+    level: level || undefined,
+    message: search || undefined,
+  });
+
+  const exportLogs = () => {
+    const blob = new Blob([symbolicLogger.export()], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'symbolic-logs.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const shareLogs = async () => {
+    await fetch('/api/share-symbolic-logs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: symbolicLogger.export(),
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex space-x-2">
+        <input
+          className="border px-2 py-1 flex-1"
+          placeholder="Filter level"
+          value={level}
+          onChange={(e) => setLevel(e.target.value)}
+        />
+        <input
+          className="border px-2 py-1 flex-1"
+          placeholder="Search message"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <button className="border px-2" onClick={exportLogs}>Export</button>
+        <button className="border px-2" onClick={shareLogs}>Share</button>
+      </div>
+      <ul className="text-sm space-y-1 max-h-60 overflow-auto border p-2">
+        {logs.map((log, idx) => (
+          <li key={idx} className="font-mono">
+            {new Date(log.timestamp).toLocaleTimeString()} [{log.level}] {log.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/solomon-reasoning-engine/src/components/WisdomThread.tsx
+++ b/solomon-reasoning-engine/src/components/WisdomThread.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { getWisdomSteps, Language } from '../lib/i18n';
+
+export default function WisdomThread() {
+  const [lang, setLang] = useState<Language>('EN');
+  const steps = getWisdomSteps(lang);
+
+  return (
+    <div className="space-y-2">
+      <select
+        className="border px-2 py-1"
+        value={lang}
+        onChange={(e) => setLang(e.target.value as Language)}
+      >
+        <option value="EN">EN</option>
+        <option value="NL">NL</option>
+        <option value="PAP">PAP</option>
+      </select>
+      <ul className="space-y-1">
+        {steps.map((step, idx) => (
+          <motion.li
+            key={idx}
+            initial={{ opacity: 0, x: -10 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: idx * 0.1 }}
+            className="border p-2 rounded"
+          >
+            {step}
+          </motion.li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/solomon-reasoning-engine/src/hooks/useSymbolicLog.ts
+++ b/solomon-reasoning-engine/src/hooks/useSymbolicLog.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import { symbolicLogger, SymbolicLog } from '../lib/symbolicLogger';
+
+export function useSymbolicLog(interval = 1000, filter?: Partial<SymbolicLog>) {
+  const [logs, setLogs] = useState<SymbolicLog[]>(symbolicLogger.getLogs(filter));
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setLogs(symbolicLogger.getLogs(filter));
+    }, interval);
+    return () => clearInterval(id);
+  }, [interval, filter]);
+
+  return logs;
+}

--- a/solomon-reasoning-engine/src/lib/i18n.ts
+++ b/solomon-reasoning-engine/src/lib/i18n.ts
@@ -1,0 +1,23 @@
+export type Language = 'EN' | 'NL' | 'PAP';
+
+const translations: Record<Language, string[]> = {
+  EN: [
+    'Understand the question clearly',
+    'Seek wisdom from diverse sources',
+    'Distill the essence and respond'
+  ],
+  NL: [
+    'Begrijp de vraag duidelijk',
+    'Zoek wijsheid uit verschillende bronnen',
+    'Destilleer de essentie en antwoord'
+  ],
+  PAP: [
+    'Kompronde bien e pregunta',
+    'Buska sabiduria for di diferente fuente',
+    'Saká esensia i kontesta'
+  ]
+};
+
+export function getWisdomSteps(lang: Language = 'EN'): string[] {
+  return translations[lang] || translations.EN;
+}

--- a/solomon-reasoning-engine/src/lib/symbolicLogger.ts
+++ b/solomon-reasoning-engine/src/lib/symbolicLogger.ts
@@ -1,0 +1,41 @@
+export type SymbolicLog = {
+  timestamp: number;
+  level: string;
+  message: string;
+};
+
+class SymbolicLogger {
+  private logs: SymbolicLog[] = [];
+
+  log(level: string, message: string) {
+    const entry: SymbolicLog = { timestamp: Date.now(), level, message };
+    this.logs.push(entry);
+    return entry;
+  }
+
+  info(message: string) {
+    return this.log('info', message);
+  }
+
+  error(message: string) {
+    return this.log('error', message);
+  }
+
+  getLogs(filter?: Partial<SymbolicLog>): SymbolicLog[] {
+    return this.logs.filter((l) => {
+      if (filter?.level && l.level !== filter.level) return false;
+      if (filter?.message && !l.message.includes(filter.message)) return false;
+      return true;
+    });
+  }
+
+  clear() {
+    this.logs = [];
+  }
+
+  export(): string {
+    return JSON.stringify(this.logs, null, 2);
+  }
+}
+
+export const symbolicLogger = new SymbolicLogger();


### PR DESCRIPTION
## Summary
- implement basic `symbolicLogger` for in-memory logging
- add `useSymbolicLog` hook for polling logs
- create `SymbolicLogView` UI with filter, export and share actions
- scaffold `/api/share-symbolic-logs.ts` webhook handler
- document symbolic log features in READMEs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868067092fc832ab69f90767ecf9388