### PR TITLE
Add WisdomThread and ReasoningTabs components

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ Automated checks for linting, build, type safety.
 
 ---
 
-## 🧵 Wisdom Thread Preview
+## 🧵 Wisdom Renderer
 
-> *“The sage never stops exploring the thread — the thread never stops exploring the sage.”*
+```tsx
+import ReasoningTabs from '@/components/ReasoningTabs'
 
-Coming soon: Interactive Wisdom Thread Renderer powered by `treeofthought`.
+<ReasoningTabs />
+```
 
 ---
 

--- a/solomon-reasoning-engine/src/components
+++ b/solomon-reasoning-engine/src/components
@@ -1,1 +1,0 @@
-# This file is intentionally left blank.

--- a/solomon-reasoning-engine/src/components/ReasoningTabs.tsx
+++ b/solomon-reasoning-engine/src/components/ReasoningTabs.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import WisdomThread from './WisdomThread';
+
+export default function ReasoningTabs() {
+  const [tab, setTab] = useState<'thread' | 'about'>('thread');
+
+  return (
+    <div className="w-full">
+      <div className="flex border-b mb-4">
+        <button
+          className={`px-4 py-2 ${tab === 'thread' ? 'border-b-2 font-semibold' : ''}`}
+          onClick={() => setTab('thread')}
+        >
+          Thread
+        </button>
+        <button
+          className={`px-4 py-2 ${tab === 'about' ? 'border-b-2 font-semibold' : ''}`}
+          onClick={() => setTab('about')}
+        >
+          About
+        </button>
+      </div>
+      {tab === 'thread' && (
+        <WisdomThread />
+      )}
+      {tab === 'about' && (
+        <div className="p-4">Toggle between tabs to explore the Wisdom Thread.</div>
+      )}
+    </div>
+  );
+}

--- a/solomon-reasoning-engine/src/components/WisdomThread.tsx
+++ b/solomon-reasoning-engine/src/components/WisdomThread.tsx
@@ -1,0 +1,44 @@
+import { motion } from 'framer-motion';
+import { t, SUPPORTED_LANGUAGES } from '@/lib/i18n';
+import { useState } from 'react';
+
+export default function WisdomThread({ lang = 'en' }: { lang?: string }) {
+  const [steps, setSteps] = useState([
+    'What is the root of wisdom?',
+    'Observe without judging.',
+    'Synthesize emotional and symbolic cues.',
+    'Proceed with care, iterate with clarity.'
+  ]);
+
+  const [selectedLang, setSelectedLang] = useState(lang);
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center gap-2">
+        <h2 className="text-xl font-bold">{t(selectedLang, 'THREAD')}</h2>
+        <select
+          value={selectedLang}
+          onChange={(e) => setSelectedLang(e.target.value)}
+          className="ml-auto border rounded px-2 py-1"
+        >
+          {SUPPORTED_LANGUAGES.map((code) => (
+            <option key={code} value={code}>{code.toUpperCase()}</option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-2">
+        {steps.map((step, i) => (
+          <motion.div
+            key={i}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: i * 0.4 }}
+            className="bg-gray-100 p-3 rounded-xl shadow-sm"
+          >
+            <span className="text-sm text-gray-700">{step}</span>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add multilingual WisdomThread renderer
- implement simple tabbed UI via ReasoningTabs
- update README with `<ReasoningTabs />` example

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868fb67e758832a9106029ee4418ffd